### PR TITLE
feat: added Amazon Bedrock Stable Diffusion SD3 models

### DIFF
--- a/src/Amazon.Bedrock/src/Predefined/Meta.cs
+++ b/src/Amazon.Bedrock/src/Predefined/Meta.cs
@@ -24,7 +24,7 @@ public class Llama3With8BInstructBModel(BedrockProvider provider)
 
 /// <inheritdoc />
 public class Llama3With70BInstructBModel(BedrockProvider provider)
-    : MetaLlamaChatModel(provider, id: "meta.llama3-8b-instruct-v1:0");
+    : MetaLlamaChatModel(provider, id: "meta.llama3-70b-instruct-v1:0");
 
 /// <inheritdoc />
 public class Llama31With70BInstructBModel(BedrockProvider provider)
@@ -33,3 +33,7 @@ public class Llama31With70BInstructBModel(BedrockProvider provider)
 /// <inheritdoc />
 public class Llama31With8BInstructBModel(BedrockProvider provider)
     : MetaLlamaChatModel(provider, id: "meta.llama3-1-8b-instruct-v1:0");
+
+/// <inheritdoc />
+public class Llama31With405BInstructBModel(BedrockProvider provider)
+    : MetaLlamaChatModel(provider, id: "meta.llama3-1-405b-instruct-v1:0");

--- a/src/Amazon.Bedrock/src/Predefined/Stability.cs
+++ b/src/Amazon.Bedrock/src/Predefined/Stability.cs
@@ -2,5 +2,17 @@
 namespace LangChain.Providers.Amazon.Bedrock.Predefined.Stability;
 
 /// <inheritdoc />
-public class StableDiffusionExtraLargeV1Model(BedrockProvider provider)
-    : StableDiffusionTextToImageModel(provider, id: "stability.stable-diffusion-xl-v1");
+public class StableDiffusionSDXLModel(BedrockProvider provider)
+    : StableDiffusionTextToImageV1Model(provider, id: "stability.stable-diffusion-xl-v1");
+
+/// <inheritdoc />
+public class StableDiffusionSD3LargeModel(BedrockProvider provider)
+    : StableDiffusionTextToImageV2Model(provider, id: "stability.sd3-large-v1:0");
+
+/// <inheritdoc />
+public class StableDiffusionImageCoreModel(BedrockProvider provider)
+    : StableDiffusionTextToImageV2Model(provider, id: "stability.stable-image-core-v1:0");
+
+/// <inheritdoc />
+public class StableDiffusionImageUltraModel(BedrockProvider provider)
+    : StableDiffusionTextToImageV2Model(provider, id: "stability.stable-image-ultra-v1:0");

--- a/src/Amazon.Bedrock/src/TextToImage/Settings/BedrockImageSettings.cs
+++ b/src/Amazon.Bedrock/src/TextToImage/Settings/BedrockImageSettings.cs
@@ -1,5 +1,5 @@
 // ReSharper disable once CheckNamespace
-namespace LangChain.Providers.Amazon.Bedrock;
+namespace LangChain.Providers.Amazon.Bedrock.TextToImage.Settings;
 
 public class BedrockImageSettings : TextToImageSettings
 {

--- a/src/Amazon.Bedrock/src/TextToImage/Settings/StableDiffusionSD3Settings.cs
+++ b/src/Amazon.Bedrock/src/TextToImage/Settings/StableDiffusionSD3Settings.cs
@@ -1,0 +1,67 @@
+// ReSharper disable once CheckNamespace
+namespace LangChain.Providers.Amazon.Bedrock;
+
+public class StableDiffusionSettings : TextToImageSettings
+{
+    public new static StableDiffusionSettings Default { get; } = new()
+    {
+        Mode = "text-to-image",
+        AspectRatio = "1:1",
+        OutputFormat = "jpeg",
+    };
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public string? Mode{ get; init; }
+    /// <summary>
+    /// 
+    /// </summary>
+    public string? AspectRatio { get; init; }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public string? OutputFormat { get; init; }
+
+    
+    /// <summary>
+    /// Calculate the settings to use for the request.
+    /// </summary>
+    /// <param name="requestSettings"></param>
+    /// <param name="modelSettings"></param>
+    /// <param name="providerSettings"></param>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    public static StableDiffusionSettings Calculate(
+        TextToImageSettings? requestSettings,
+        TextToImageSettings? modelSettings,
+        TextToImageSettings? providerSettings)
+    {
+        var requestSettingsCasted = requestSettings as StableDiffusionSettings;
+        var modelSettingsCasted = modelSettings as StableDiffusionSettings;
+        var providerSettingsCasted = providerSettings as StableDiffusionSettings;
+
+        return new StableDiffusionSettings
+        {
+            Mode =
+              requestSettingsCasted?.Mode ??
+              modelSettingsCasted?.Mode ??
+              providerSettingsCasted?.Mode ??
+              Default.Mode ??
+              throw new InvalidOperationException("Default Mode is not set."),
+            AspectRatio =
+              requestSettingsCasted?.AspectRatio ??
+              modelSettingsCasted?.AspectRatio ??
+              providerSettingsCasted?.AspectRatio ??
+              Default.AspectRatio ??
+              throw new InvalidOperationException("Default AspectRatio is not set."),
+            OutputFormat =
+              requestSettingsCasted?.OutputFormat ??
+              modelSettingsCasted?.OutputFormat ??
+              providerSettingsCasted?.OutputFormat ??
+              Default.OutputFormat ??
+              throw new InvalidOperationException("Default OutputFormat is not set."),
+        };
+    }
+}

--- a/src/Amazon.Bedrock/src/TextToImage/StableDiffusionImageGenerationModel.cs
+++ b/src/Amazon.Bedrock/src/TextToImage/StableDiffusionImageGenerationModel.cs
@@ -6,7 +6,7 @@ using LangChain.Providers.Amazon.Bedrock.Internal;
 // ReSharper disable once CheckNamespace
 namespace LangChain.Providers.Amazon.Bedrock;
 
-public class StableDiffusionTextToImageModel(
+public class StableDiffusionTextToImageV1Model(
     BedrockProvider provider,
     string id)
     : TextToImageModel(id), ITextToImageModel

--- a/src/Amazon.Bedrock/src/TextToImage/StableDiffusionSD3Response.cs
+++ b/src/Amazon.Bedrock/src/TextToImage/StableDiffusionSD3Response.cs
@@ -1,0 +1,10 @@
+﻿using System.Text.Json.Serialization;
+
+// ReSharper disable once CheckNamespace
+namespace LangChain.Providers.Amazon.Bedrock;
+
+public class StableDiffusionSD3Response
+{
+    [JsonPropertyName("images")]
+    public IReadOnlyList<string> Images { get; set; } = new List<string>();
+}

--- a/src/Amazon.Bedrock/test/BedrockTests.cs
+++ b/src/Amazon.Bedrock/test/BedrockTests.cs
@@ -233,16 +233,30 @@ Helpful Answer:";
     public async Task CanGetImage2()
     {
         var provider = new BedrockProvider();
-        var model = new StableDiffusionExtraLargeV1Model(provider);
+        var model = new StableDiffusionSDXLModel(provider);
         var response = await model.GenerateImageAsync(
             "i'm going to prepare a recipe.  show me an image of realistic food ingredients");
 
-        var path = Path.Combine(Path.GetTempPath(), "food.png");
+        var path = Path.Combine(Path.GetTempPath(), "food2.png");
 
         await File.WriteAllBytesAsync(path, response.Images[0].ToByteArray());
-
-        Process.Start(path);
     }
+
+    [Test]
+    public async Task CanGetStableDiffusionSD3Image()
+    {
+        var provider = new BedrockProvider(RegionEndpoint.USWest2);
+        var model = new StableDiffusionSD3LargeModel(provider);
+       // var model = new StableDiffusionImageCoreModel(provider);
+        //var model = new StableDiffusionImageUltraModel(provider);
+        var response = await model.GenerateImageAsync(
+            "i'm going to prepare a recipe.  show me an image of realistic food ingredients");
+
+        var path = Path.Combine(Path.GetTempPath(), "food1.png");
+
+        await File.WriteAllBytesAsync(path, response.Images[0].ToByteArray());
+    }
+
 
     [Test]
     public async Task ClaudeImageToText()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new models for text-to-image generation, including `Llama31With405BInstructBModel` and several Stable Diffusion models.
	- Added `StableDiffusionSettings` class for enhanced configuration of the Stable Diffusion model.
	- Implemented `StableDiffusionTextToImageV2Model` for improved image generation capabilities.

- **Bug Fixes**
	- Updated test cases to reflect changes in model names and output expectations.

- **Documentation**
	- Enhanced organization of model classes for better clarity and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->