### PR TITLE
feat: allow user to set granular configuration for AWS Bedrock

### DIFF
--- a/src/Amazon.Bedrock/src/BedrockProvider.cs
+++ b/src/Amazon.Bedrock/src/BedrockProvider.cs
@@ -43,6 +43,19 @@ public class BedrockProvider : Provider
         AgentApi = new AmazonBedrockAgentRuntimeClient(accessKeyId, secretAccessKey, region ?? RegionEndpoint.USEast1);
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BedrockProvider"/> class with the specified configuration.
+    /// </summary>
+    /// <param name="runtimeConfig">The configuration for the Amazon Bedrock Runtime service.</param>
+    /// <param name="agentRuntimeConfig">The configuration for the Amazon Bedrock Agent Runtime service.</param>
+    [CLSCompliant(false)]
+    public BedrockProvider(AmazonBedrockRuntimeConfig runtimeConfig, AmazonBedrockAgentRuntimeConfig agentRuntimeConfig)
+        : base(DefaultProviderId)
+    {
+        Api = new AmazonBedrockRuntimeClient(runtimeConfig);
+        AgentApi = new AmazonBedrockAgentRuntimeClient(agentRuntimeConfig);
+    }
+
     #region Properties
 
     [CLSCompliant(false)]


### PR DESCRIPTION
Hello,

This small PR allows developers to directly set the AWS configuration themselves when the simpler constructors are not enough for their use-case. This would help me out a lot. Thanks for considering it!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for initializing BedrockProvider with enhanced configuration options, allowing for more flexible setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->