### PR TITLE
Add Microsoft.Extensions.AI provider

### DIFF
--- a/LangChain.Providers.sln
+++ b/LangChain.Providers.sln
@@ -174,6 +174,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Examples.OpenRouter", "Exam
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LangChain.Providers.HuggingFace", "src\HuggingFace\src\LangChain.Providers.HuggingFace.csproj", "{557FE99B-E1B1-4F43-BC8A-BBB9CDD88C5A}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Microsoft.Extensions.AI", "Microsoft.Extensions.AI", "{C49BCF4F-C39A-2144-835C-D4ACE8A5F0C8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LangChain.Providers.MicrosoftExtensionsAI", "src\MicrosoftExtensionsAI\src\LangChain.Providers.MicrosoftExtensionsAI.csproj", "{089B4E95-B67E-8C82-C479-75C508F8C95A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -324,6 +328,10 @@ Global
 		{557FE99B-E1B1-4F43-BC8A-BBB9CDD88C5A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{557FE99B-E1B1-4F43-BC8A-BBB9CDD88C5A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{557FE99B-E1B1-4F43-BC8A-BBB9CDD88C5A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{089B4E95-B67E-8C82-C479-75C508F8C95A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{089B4E95-B67E-8C82-C479-75C508F8C95A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{089B4E95-B67E-8C82-C479-75C508F8C95A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{089B4E95-B67E-8C82-C479-75C508F8C95A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -393,6 +401,8 @@ Global
 		{A22FAE09-1EF8-46B7-A319-0BA5A9791DBF} = {D843DAF5-9B48-4F05-9A5C-C2AD1209BF24}
 		{9622C708-4848-460B-A4F6-9E05EFA9EB18} = {A22FAE09-1EF8-46B7-A319-0BA5A9791DBF}
 		{557FE99B-E1B1-4F43-BC8A-BBB9CDD88C5A} = {91B13316-6565-4CB6-9876-945FFE2DD20C}
+		{C49BCF4F-C39A-2144-835C-D4ACE8A5F0C8} = {E2B9833C-0397-4FAF-A3A8-116E58749750}
+		{089B4E95-B67E-8C82-C479-75C508F8C95A} = {C49BCF4F-C39A-2144-835C-D4ACE8A5F0C8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5C00D0F1-6138-4ED9-846B-97E43D6DFF1C}

--- a/src/IntegrationTests/BaseTests.cs
+++ b/src/IntegrationTests/BaseTests.cs
@@ -18,6 +18,7 @@ public class BaseTests
     [TestCase(ProviderType.DeepInfra)]
     [TestCase(ProviderType.DeepSeek)]
     //[TestCase(ProviderType.Ollama)]
+    [TestCase(ProviderType.MicrosoftExtensionsAI)]
     public async Task FiveRandomWords(ProviderType providerType)
     {
         var requests = new List<ChatRequest>();
@@ -68,7 +69,7 @@ public class BaseTests
         }
 
         llm.Usage.Should().BeEquivalentTo(response.Usage);
-        provider.Usage.Should().BeEquivalentTo(response.Usage);
+        provider?.Usage.Should().BeEquivalentTo(response.Usage);
 
         response.Messages.Should().HaveCount(2);
         response.Messages[0].Role.Should().Be(MessageRole.Human);
@@ -93,6 +94,7 @@ public class BaseTests
     [TestCase(ProviderType.DeepInfra)]
     [TestCase(ProviderType.DeepSeek)]
     //[TestCase(ProviderType.Ollama)]
+    [TestCase(ProviderType.MicrosoftExtensionsAI)]
     public async Task FiveRandomWords_Streaming(ProviderType providerType)
     {
         var stopwatch = Stopwatch.StartNew();
@@ -162,7 +164,7 @@ public class BaseTests
         }
 
         llm.Usage.Should().BeEquivalentTo(lastResponse.Usage);
-        provider.Usage.Should().BeEquivalentTo(lastResponse.Usage);
+        provider?.Usage.Should().BeEquivalentTo(lastResponse.Usage);
 
         lastResponse.Messages.Should().HaveCount(2);
         lastResponse.Messages[0].Role.Should().Be(MessageRole.Human);
@@ -186,6 +188,7 @@ public class BaseTests
     //[TestCase(ProviderType.Anthropic)]
     //[TestCase(ProviderType.DeepInfra)]
     [TestCase(ProviderType.DeepSeek)]
+    [TestCase(ProviderType.MicrosoftExtensionsAI)]
     public async Task SimpleChain(ProviderType providerType)
     {
         var (llm, _, _) = Helpers.GetModels(providerType);
@@ -214,6 +217,7 @@ public class BaseTests
     // [TestCase(ProviderType.Anthropic)]
     // [TestCase(ProviderType.DeepInfra)]
     // [TestCase(ProviderType.DeepSeek)]
+    [TestCase(ProviderType.MicrosoftExtensionsAI)]
     public async Task Tools_Weather(ProviderType providerType)
     {
         var (llm, _, _) = Helpers.GetModels(providerType);
@@ -229,7 +233,7 @@ public class BaseTests
             });
         response.Usage.InputTokens.Should().BeGreaterThan(0);
         response.Usage.OutputTokens.Should().BeGreaterThan(0);
-        response.Usage.PriceInUsd.Should().BeGreaterThan(0);
+        response.Usage.PriceInUsd?.Should().BeGreaterThan(0);
 
         Console.WriteLine(response.Messages.AsHistory());
     }
@@ -243,6 +247,7 @@ public class BaseTests
     //[TestCase(ProviderType.DeepInfra)]
     //[TestCase(ProviderType.Google)]
     //[TestCase(ProviderType.Anthropic)]
+    [TestCase(ProviderType.MicrosoftExtensionsAI)]
     public async Task Tools_Books(ProviderType providerType)
     {
         var (llm, _, _) = Helpers.GetModels(providerType);
@@ -257,7 +262,7 @@ public class BaseTests
             });
         response.Usage.InputTokens.Should().BeGreaterThan(0);
         response.Usage.OutputTokens.Should().BeGreaterThan(0);
-        response.Usage.PriceInUsd.Should().BeGreaterThan(0);
+        response.Usage.PriceInUsd?.Should().BeGreaterThan(0);
 
         Console.WriteLine(response.Messages.AsHistory());
     }

--- a/src/IntegrationTests/EmbeddingModel_Tests.cs
+++ b/src/IntegrationTests/EmbeddingModel_Tests.cs
@@ -105,36 +105,16 @@ public class EmbeddingModel_Tests
         "Necessity knows no law.",
         "Failing to prepare is preparing to fail."
     };
+
     [Explicit]
-    public async Task GoogleEmbeddingTest()
+    public async Task GoogleEmbeddingTest() => await EmbeddingTest(ProviderType.Google);
+
+    [TestCase(ProviderType.Together)]
+    [TestCase(ProviderType.DeepInfra)]
+    [TestCase(ProviderType.MicrosoftExtensionsAI)]
+    public async Task EmbeddingTest(ProviderType providerType)
     {
-        var (llm, embeddingModel, _) = Helpers.GetModels(ProviderType.Google);
-
-        var embeddings = await embeddingModel.CreateEmbeddingsAsync(new EmbeddingRequest()
-        {
-            Strings = this.Strings
-        });
-        embeddings.Values.Should().HaveCountGreaterThan(0);
-        embeddings.Values.First().Should().HaveCountGreaterThan(0);
-    }
-
-    [TestCase]
-    public async Task TogetherEmbeddingTest()
-    {
-        var (llm, embeddingModel, _) = Helpers.GetModels(ProviderType.Together);
-
-        var embeddings = await embeddingModel.CreateEmbeddingsAsync(new EmbeddingRequest()
-        {
-            Strings = this.Strings
-        });
-        embeddings.Values.Should().HaveCountGreaterThan(0);
-        embeddings.Values.First().Should().HaveCountGreaterThan(0);
-    }
-
-    [TestCase]
-    public async Task DeepInfraEmbeddingTest()
-    {
-        var (llm, embeddingModel, _) = Helpers.GetModels(ProviderType.DeepInfra);
+        var (llm, embeddingModel, _) = Helpers.GetModels(providerType);
 
         var embeddings = await embeddingModel.CreateEmbeddingsAsync(new EmbeddingRequest()
         {

--- a/src/IntegrationTests/Helpers.cs
+++ b/src/IntegrationTests/Helpers.cs
@@ -9,11 +9,13 @@ using LangChain.Providers.Fireworks;
 using LangChain.Providers.Google;
 using LangChain.Providers.Google.Predefined;
 using LangChain.Providers.Groq;
+using LangChain.Providers.MicrosoftExtensionsAI;
 using LangChain.Providers.Ollama;
 using LangChain.Providers.OpenAI;
 using LangChain.Providers.OpenAI.Predefined;
 using LangChain.Providers.OpenRouter;
 using LangChain.Providers.Together;
+using Microsoft.Extensions.AI;
 
 namespace LangChain.IntegrationTests;
 
@@ -139,6 +141,16 @@ public static class Helpers
             //
             //         return (llm, embeddings, provider);
             //     }
+            case ProviderType.MicrosoftExtensionsAI:
+                {
+                    string apikey =
+                        Environment.GetEnvironmentVariable("OPENAI_API_KEY") ??
+                        throw new InconclusiveException("OPENAI_API_KEY is not set");
+
+                    IChatClient client = new OpenAI.Chat.ChatClient("gpt-4o", apikey).AsIChatClient();
+                    IEmbeddingGenerator embeddingGenerator = new OpenAI.Embeddings.EmbeddingClient("text-embedding-3-small", apikey).AsIEmbeddingGenerator();
+                    return (new ChatClientModel(client), new EmbeddingGeneratorModel(embeddingGenerator), null!);
+                }
             case ProviderType.Groq:
                 {
                     var config = new GroqConfiguration()

--- a/src/IntegrationTests/LangChain.IntegrationTests.csproj
+++ b/src/IntegrationTests/LangChain.IntegrationTests.csproj
@@ -19,12 +19,14 @@
         <ProjectReference Include="..\Ollama\src\LangChain.Providers.Ollama.csproj" />
         <ProjectReference Include="..\OpenRouter\src\LangChain.Providers.OpenRouter.csproj" />
         <ProjectReference Include="..\TogetherAI\src\LangChain.Providers.Together.csproj" />
+        <ProjectReference Include="..\MicrosoftExtensionsAI\src\LangChain.Providers.MicrosoftExtensionsAI.csproj" />
     </ItemGroup>
 
     <ItemGroup>
       <PackageReference Include="LangChain.Core" Version="0.17.1-dev.51" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="System.Text.Json" Version="9.0.6" />
+      <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.6.0-preview.1.25310.2" />
     </ItemGroup>
 
 </Project>

--- a/src/IntegrationTests/ProviderType.cs
+++ b/src/IntegrationTests/ProviderType.cs
@@ -16,4 +16,5 @@ public enum ProviderType
     Reka,
     GitHub,
     Ollama,
+    MicrosoftExtensionsAI,
 }

--- a/src/MicrosoftExtensionsAI/src/ChatClientModel.cs
+++ b/src/MicrosoftExtensionsAI/src/ChatClientModel.cs
@@ -1,0 +1,223 @@
+﻿using CSharpToJsonSchema;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+
+namespace LangChain.Providers.MicrosoftExtensionsAI;
+
+/// <summary>Provides a <see cref="IChatModel"/> based on an <see cref="IChatClient"/>.</summary>
+public sealed class ChatClientModel : ChatModel, IChatModel
+{
+    private readonly IChatClient _clientWithFunctionInvocation;
+
+    /// <summary>Initializes a new instance of the <see cref="ChatClientModel"/>.</summary>
+    /// <param name="client">The <see cref="IChatClient"/> to use for inference.</param>
+    /// <param name="id">The ID to use for the <see cref="ChatModel"/>.</param>
+    public ChatClientModel(IChatClient client, string? id = null) : base(id ?? $"chatClient{Guid.NewGuid():N}")
+    {
+        Client = client ?? throw new ArgumentNullException(nameof(client));
+
+        _clientWithFunctionInvocation = client.GetService<FunctionInvokingChatClient>() is null ?
+            new FunctionInvokingChatClient(client) :
+            client;
+    }
+
+    /// <summary>Gets the underlying <see cref="IChatClient"/>.</summary>
+    public IChatClient Client { get; }
+
+    /// <inheritdoc />
+    public override async IAsyncEnumerable<ChatResponse> GenerateAsync(
+        ChatRequest request,
+        ChatSettings? settings = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        _ = request ?? throw new ArgumentNullException(nameof(request));
+
+        IChatClient client = CallToolsAutomatically ? _clientWithFunctionInvocation : Client;
+
+        settings ??= ChatSettings.Default;
+        ChatOptions? options =
+            settings is ChatClientSettings chatClientSettings ? chatClientSettings.Options :
+            settings.StopSequences is { Count: > 0 } stopSequences ? new ChatOptions { StopSequences = [.. stopSequences] } :
+            null;
+
+        options ??= new ChatOptions();
+        foreach (var tool in request.Tools.Concat(GlobalTools))
+        {
+            (options.Tools ??= []).Add(new ToolAIFunction(tool, Calls));
+        }
+
+        List<ChatMessage> messages = request.Messages is { Count: > 0 } requestMessages ?
+            requestMessages.Select(m =>
+            {
+                ChatRole role = m.Role switch
+                {
+                    MessageRole.Human => ChatRole.User,
+                    MessageRole.System => ChatRole.System,
+                    MessageRole.ToolResult => ChatRole.Tool,
+                    _ => ChatRole.Assistant,
+                };
+
+                return new ChatMessage(role, m.Content);
+            }).ToList() : [];
+
+        OnRequestSent(request);
+        Stopwatch sw = Stopwatch.StartNew();
+
+        ChatResponse langchainResponse;
+        if (settings?.UseStreaming ?? false)
+        {
+            List<ChatResponseUpdate> updates = [];
+            await foreach (var update in client.GetStreamingResponseAsync(messages, options, cancellationToken).ConfigureAwait(false))
+            {
+                List<Message>? updateMessages = null;
+                UsageDetails? usageDetails = null;
+                updates.Add(update);
+                foreach (var content in update.Contents)
+                {
+                    switch (content)
+                    {
+                        case TextContent tc:
+                            OnDeltaReceived(new ChatResponseDelta { Content = tc.Text });
+                            break;
+
+                        case UsageContent uc:
+                            if (usageDetails is null)
+                            {
+                                usageDetails = uc.Details;
+                            }
+                            else
+                            {
+                                usageDetails.Add(uc.Details);
+                            }
+                            break;
+                    }
+
+                    if (ToMessage(update.Role, content) is { } message)
+                    {
+                        (updateMessages ??= []).Add(message);
+                    }
+                }
+
+                if (updateMessages is not null)
+                {
+                    yield return new ChatResponse
+                    {
+                        Messages = updateMessages,
+                        UsedSettings = settings!,
+                        Usage = ToUsage(usageDetails, sw),
+                    };
+                }
+            }
+
+            langchainResponse = ToResponse(request, updates.ToChatResponse(), sw, settings, request.Messages.Count);
+        }
+        else
+        {
+            var response = await client.GetResponseAsync(messages, options, cancellationToken).ConfigureAwait(false);
+            OnDeltaReceived(new ChatResponseDelta() { Content = response.Text });
+
+            langchainResponse = ToResponse(request, response, sw, settings, request.Messages.Count);
+        }
+
+        AddUsage(langchainResponse.Usage);
+        OnResponseReceived(langchainResponse);
+        yield return langchainResponse;
+    }
+
+    private static ChatResponse ToResponse(
+        ChatRequest request, Microsoft.Extensions.AI.ChatResponse response, Stopwatch sw, ChatSettings? settings, int messageCount = 0)
+    {
+        List<Message> responseMessages = [];
+        foreach (var message in response.Messages)
+        {
+            MessageRole role = ToMessageRole(message.Role);
+            foreach (var content in message.Contents)
+            {
+                if (ToMessage(message.Role, content) is { } msg)
+                {
+                    responseMessages.Add(msg);
+                }
+            }
+        }
+
+        return new()
+        {
+            FinishReason =
+                response.FinishReason == ChatFinishReason.Stop ? ChatResponseFinishReason.Stop :
+                response.FinishReason == ChatFinishReason.Length ? ChatResponseFinishReason.Length :
+                response.FinishReason == ChatFinishReason.ToolCalls ? ChatResponseFinishReason.ToolCalls :
+                response.FinishReason == ChatFinishReason.ContentFilter ? ChatResponseFinishReason.ContentFilter :
+                null,
+
+            UsedSettings = settings ?? new(),
+
+            Messages = [..request.Messages, ..responseMessages],
+
+            ToolCalls = [.. response.Messages.SelectMany(m => m.Contents).OfType<FunctionCallContent>().Select(fc => new ChatToolCall
+                {
+                    Id = fc.Name,
+                    ToolName = fc.Name,
+                    ToolArguments = JsonSerializer.Serialize(fc.Arguments, OpenApiSchemaJsonContext.Default.IDictionaryStringObject),
+                })],
+
+            Usage = ToUsage(response.Usage, sw, messageCount),
+        };
+    }
+
+    private static Usage ToUsage(UsageDetails? usageDetails, Stopwatch sw, int messageCount = 0) =>
+        usageDetails is null && messageCount == 0 ?
+            Usage.Empty :
+            new Usage
+            {
+                InputTokens = (int?)usageDetails?.InputTokenCount ?? 0,
+                OutputTokens = (int?)usageDetails?.OutputTokenCount ?? 0,
+                Messages = messageCount,
+                Time = sw.Elapsed,
+            };
+
+    private static MessageRole ToMessageRole(ChatRole? role) =>
+        role == ChatRole.User ? MessageRole.Human :
+        role == ChatRole.Assistant ? MessageRole.Ai :
+        role == ChatRole.System ? MessageRole.System :
+        role == ChatRole.Tool ? MessageRole.ToolResult :
+        MessageRole.Chat;
+
+    private static Message? ToMessage(ChatRole? role, AIContent content) => 
+        content switch
+        {
+            TextContent textContent => (Message?)new Message(textContent.Text, ToMessageRole(role)),
+            FunctionCallContent functionCallContent => (Message?)new Message
+            {
+                Role = ToMessageRole(role),
+                ToolName = functionCallContent.Name,
+            },
+            _ => null,
+        };
+
+    private sealed class ToolAIFunction(Tool tool, Dictionary<string, Func<string, CancellationToken, Task<string>>>? calls) : AIFunction
+    {
+        public override string Name => tool.Name ?? base.Name;
+
+        public override string Description => tool.Description ?? base.Description;
+
+        public override JsonElement JsonSchema { get; } =
+            tool.Parameters is not null ?
+                JsonSerializer.SerializeToElement(tool.Parameters, OpenApiSchemaJsonContext.Default.GetTypeInfo(tool.Parameters.GetType())!) :
+                default;
+
+        public override JsonSerializerOptions JsonSerializerOptions => OpenApiSchemaJsonContext.Default.Options;
+
+        protected override ValueTask<object?> InvokeCoreAsync(AIFunctionArguments arguments, CancellationToken cancellationToken)
+        {
+            if (calls is null || !calls.TryGetValue(Name, out var call))
+            {
+                throw new InvalidOperationException($"No function call registered for tool '{Name}'.");
+            }
+
+            string args = JsonSerializer.Serialize(arguments, OpenApiSchemaJsonContext.Default.IDictionaryStringObject);
+
+            return new ValueTask<object?>(call(args, cancellationToken));
+        }
+    }
+}

--- a/src/MicrosoftExtensionsAI/src/ChatClientSettings.cs
+++ b/src/MicrosoftExtensionsAI/src/ChatClientSettings.cs
@@ -1,0 +1,9 @@
+// ReSharper disable once CheckNamespace
+namespace LangChain.Providers.MicrosoftExtensionsAI;
+
+/// <summary>Settings for use with a <see cref="ChatClientModel"/>.</summary>
+public sealed class ChatClientSettings : ChatSettings
+{
+    /// <summary>Gets or sets the <see cref="ChatOptions"/> to use with a request to the <see cref="IChatClient"/>.</summary>
+    public ChatOptions? Options { get; set; }
+}

--- a/src/MicrosoftExtensionsAI/src/EmbeddingGeneratorModel.cs
+++ b/src/MicrosoftExtensionsAI/src/EmbeddingGeneratorModel.cs
@@ -1,0 +1,72 @@
+﻿namespace LangChain.Providers.MicrosoftExtensionsAI;
+
+/// <summary>Provides an <see cref="IEmbeddingModel"/> based on an <see cref="IEmbeddingGenerator"/>.</summary>
+public sealed class EmbeddingGeneratorModel : Model<EmbeddingSettings>, IEmbeddingModel
+{
+    /// <summary>Initializes a new instance of the <see cref="EmbeddingGeneratorModel"/>.</summary>
+    /// <param name="generator">The <see cref="IEmbeddingGenerator"/> to use.</param>
+    /// <param name="id">The ID to use for the <see cref="IEmbeddingModel"/>.</param>
+    public EmbeddingGeneratorModel(IEmbeddingGenerator generator, string? id = null) : base(id ?? $"embeddingGenerator{Guid.NewGuid():N}")
+    {
+        Generator = generator ?? throw new ArgumentNullException(nameof(generator));
+    }
+
+    /// <summary>Gets the underlying <see cref="IEmbeddingGenerator"/>.</summary>
+    public IEmbeddingGenerator Generator { get; }
+
+    /// <inheritdoc />
+    public async Task<EmbeddingResponse> CreateEmbeddingsAsync(
+        EmbeddingRequest request,
+        EmbeddingSettings? settings = null,
+        CancellationToken cancellationToken = default)
+    {
+        _ = request ?? throw new ArgumentNullException(nameof(request));
+
+        if (request.Images is { Count: > 0 } && request.Strings.Count > 0)
+        {
+            throw new ArgumentException("Request cannot contain both images and strings.");
+        }
+
+        settings ??= EmbeddingSettings.Default;
+        EmbeddingGenerationOptions? options =
+            settings is EmbeddingGeneratorSettings generatorSettings ? generatorSettings.Options :
+            null;
+
+        if (request.Strings is { Count: > 0 } strings)
+        {
+            return Generator is IEmbeddingGenerator<string, Embedding<float>> generator ? 
+                Process(await generator.GenerateAsync(strings, options, cancellationToken).ConfigureAwait(false)) :
+                throw new InvalidOperationException("The generator does not support string embeddings.");
+        }
+        
+        if (request.Images is { Count: > 0 } images)
+        {
+            return Generator is IEmbeddingGenerator<DataContent, Embedding<float>> generator ?
+                Process(await generator.GenerateAsync([.. images.Select(i => new DataContent(i.ToByteArray(), "image/*"))], options, cancellationToken).ConfigureAwait(false)) :
+                throw new InvalidOperationException("The generator does not support string embeddings.");
+        }
+        
+        return Process([]);
+
+        EmbeddingResponse Process(GeneratedEmbeddings<Embedding<float>> results)
+        {
+            Usage usage = results.Usage is { } resultsUsage ?
+                new Usage
+                {
+                    InputTokens = (int?)resultsUsage.InputTokenCount ?? 0,
+                    OutputTokens = (int?)resultsUsage.OutputTokenCount ?? 0,
+                } :
+                Usage.Empty;
+
+            AddUsage(usage);
+
+            return new EmbeddingResponse
+            {
+                Dimensions = results.FirstOrDefault()?.Vector.Length ?? 0,
+                UsedSettings = settings,
+                Usage = usage,
+                Values = [.. results.Select(r => r.Vector.ToArray())],
+            };
+        }
+    }
+}

--- a/src/MicrosoftExtensionsAI/src/EmbeddingGeneratorModel.cs
+++ b/src/MicrosoftExtensionsAI/src/EmbeddingGeneratorModel.cs
@@ -43,7 +43,7 @@ public sealed class EmbeddingGeneratorModel : Model<EmbeddingSettings>, IEmbeddi
         {
             return Generator is IEmbeddingGenerator<DataContent, Embedding<float>> generator ?
                 Process(await generator.GenerateAsync([.. images.Select(i => new DataContent(i.ToByteArray(), "image/*"))], options, cancellationToken).ConfigureAwait(false)) :
-                throw new InvalidOperationException("The generator does not support string embeddings.");
+                throw new InvalidOperationException("The generator does not support image embeddings.");
         }
         
         return Process([]);

--- a/src/MicrosoftExtensionsAI/src/EmbeddingGeneratorSettings.cs
+++ b/src/MicrosoftExtensionsAI/src/EmbeddingGeneratorSettings.cs
@@ -1,0 +1,9 @@
+// ReSharper disable once CheckNamespace
+namespace LangChain.Providers.MicrosoftExtensionsAI;
+
+/// <summary>Settings for use with a <see cref="EmbeddingGeneratorModel"/>.</summary>
+public sealed class EmbeddingGeneratorSettings : EmbeddingSettings
+{
+    /// <summary>Gets or sets the <see cref="EmbeddingGenerationOptions"/> to use with a request to the <see cref="IEmbeddingGenerator"/>.</summary>
+    public EmbeddingGenerationOptions? Options { get; set; }
+}

--- a/src/MicrosoftExtensionsAI/src/LangChain.Providers.MicrosoftExtensionsAI.csproj
+++ b/src/MicrosoftExtensionsAI/src/LangChain.Providers.MicrosoftExtensionsAI.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>net4.6.2;netstandard2.0;net8.0;net9.0</TargetFrameworks>
+        <NoWarn>$(NoWarn);CA1002;CS3001;CS3003</NoWarn>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.6.0" />
+      <PackageReference Include="Microsoft.Extensions.AI" Version="9.6.0" />
+        <PackageReference Include="LangChain.Polyfills" Version="0.17.1-dev.47" />
+    </ItemGroup>
+
+    <ItemGroup Label="Usings">
+        <Using Include="Microsoft.Extensions.AI" />
+        <Using Include="System.Net.Http" />
+    </ItemGroup>
+
+    <PropertyGroup Label="NuGet">
+        <Description>Microsoft.Extensions.AI LLM and Chat model provider.</Description>
+        <PackageTags>$(PackageTags);openai;api</PackageTags>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\Abstractions\src\LangChain.Providers.Abstractions.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/MicrosoftExtensionsAI/src/SpeechToTextClientModel.cs
+++ b/src/MicrosoftExtensionsAI/src/SpeechToTextClientModel.cs
@@ -1,0 +1,49 @@
+using System.Diagnostics.CodeAnalysis;
+
+#pragma warning disable CA1849
+
+namespace LangChain.Providers.MicrosoftExtensionsAI;
+
+/// <summary>Provides an <see cref="ISpeechToTextModel"/> based on an <see cref="ISpeechToTextClient"/>.</summary>
+[Experimental("MEAI001")]
+public sealed class SpeechToTextClientModel : Model<SpeechToTextSettings>, ISpeechToTextModel
+{
+    /// <summary>Initializes a new instance of the <see cref="SpeechToTextClientModel"/>.</summary>
+    /// <param name="client">The <see cref="ISpeechToTextClient"/> to use.</param>
+    /// <param name="id">The ID to use for the <see cref="ISpeechToTextModel"/>.</param>
+    public SpeechToTextClientModel(ISpeechToTextClient client, string id) : base(id)
+    {
+        Client = client ?? throw new ArgumentNullException(nameof(client));
+    }
+
+    /// <summary>Gets the underlying <see cref="ISpeechToTextClient"/>.</summary>
+    public ISpeechToTextClient Client { get; }
+
+    /// <inheritdoc />
+    public async Task<SpeechToTextResponse> TranscribeAsync(SpeechToTextRequest request, SpeechToTextSettings? settings = null, CancellationToken cancellationToken = default)
+    {
+        _ = request ?? throw new ArgumentNullException(nameof(request));
+
+        settings ??= SpeechToTextSettings.Default;
+
+        SpeechToTextOptions? options =
+            settings is SpeechToTextClientSettings clientSettings ? clientSettings.Options :
+            null;
+
+        try
+        {
+            var response = await Client.GetTextAsync(request.Stream, options, cancellationToken).ConfigureAwait(false);
+            return new SpeechToTextResponse()
+            {
+                Text = response.Text,
+            };
+        }
+        finally
+        {
+            if (request.OwnsStream)
+            {
+                request.Stream.Dispose();
+            }
+        }
+    }
+}

--- a/src/MicrosoftExtensionsAI/src/SpeechToTextClientSettings.cs
+++ b/src/MicrosoftExtensionsAI/src/SpeechToTextClientSettings.cs
@@ -1,0 +1,12 @@
+// ReSharper disable once CheckNamespace
+using System.Diagnostics.CodeAnalysis;
+
+namespace LangChain.Providers.MicrosoftExtensionsAI;
+
+/// <summary>Settings for use with a <see cref="SpeechToTextClientModel"/>.</summary>
+[Experimental("MEAI001")]
+public sealed class SpeechToTextClientSettings : SpeechToTextSettings
+{
+    /// <summary>Gets or sets the <see cref="SpeechToTextOptions"/> to use with a request to the <see cref="ISpeechToTextClient"/>.</summary>
+    public SpeechToTextOptions? Options { get; set; }
+}


### PR DESCRIPTION
Enable any IChatClient, IEmbeddingGenerator, or ISpeechToTextClient to work with LangChain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Microsoft.Extensions.AI provider, enabling integration with chat, embedding, and speech-to-text models.
  * Introduced new settings classes for configuring chat, embedding, and speech-to-text requests with MicrosoftExtensionsAI.
  * Enhanced integration tests to cover the new provider for chat, embedding, and tool-based scenarios.

* **Bug Fixes**
  * Improved test stability by handling potential null values in usage and pricing assertions.

* **Refactor**
  * Streamlined embedding model tests by consolidating provider-specific tests into a single parameterized method.

* **Chores**
  * Updated solution and project files to include the new provider and necessary dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->