### PR TITLE
New Constructor for BedrockProvider

### DIFF
--- a/src/Amazon.Bedrock/src/BedrockProvider.cs
+++ b/src/Amazon.Bedrock/src/BedrockProvider.cs
@@ -56,6 +56,19 @@ public class BedrockProvider : Provider
         AgentApi = new AmazonBedrockAgentRuntimeClient(agentRuntimeConfig);
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BedrockProvider"/> class with the given clients.
+    /// </summary>
+    /// <param name="runtimeClient">The Amazon Bedrock Runtime client.</param>
+    /// <param name="agentRuntimeClient">The Amazon Bedrock Agent Runtime client.</param>
+    [CLSCompliant(false)]
+    public BedrockProvider(AmazonBedrockRuntimeClient runtimeClient, AmazonBedrockAgentRuntimeClient agentRuntimeClient)
+        : base(DefaultProviderId)
+    {
+        Api = runtimeClient;
+        AgentApi = agentRuntimeClient;
+    }
+
     #region Properties
 
     [CLSCompliant(false)]


### PR DESCRIPTION
Added a new constructor for BedrockProvider so the user can pass in their previously configured AWS Bedrock Clients.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now initialize the provider with existing Bedrock runtime clients, enabling dependency injection, easier testing, and custom configuration without affecting existing usage.
  * No breaking changes; existing constructors continue to work.

* **Documentation**
  * Added inline documentation for the new constructor parameters to improve discoverability and IDE hints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->